### PR TITLE
Make property used in HTML public

### DIFF
--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -10,7 +10,7 @@ import { UsuarioLogin } from 'src/app/services/login/usuario_login';
 export class LoginComponent implements OnInit {
 
     //#region Propriedades
-    private usuarioLogin: UsuarioLogin;
+    public usuarioLogin: UsuarioLogin;
     private idLoginPadrao: number;
     //#endregion
 

--- a/src/app/components/usuario/cadastro-visitante/cadastro-visitante.component.ts
+++ b/src/app/components/usuario/cadastro-visitante/cadastro-visitante.component.ts
@@ -16,7 +16,7 @@ export class CadastroVisitanteComponent implements OnInit, OnDestroy {
 
     //#region Propriedades
     private objetoErro: ObjetoErro;
-    private formularioVisitante: FormGroup;
+    public formularioVisitante: FormGroup;
     private usuarioLogin: UsuarioLogin;
     private idLoginPadrao: number;
     private solicitarCadastroVisitanteSubscription: Subscription;

--- a/src/app/paginas/downloads/downloads.component.ts
+++ b/src/app/paginas/downloads/downloads.component.ts
@@ -20,7 +20,7 @@ export class DownloadsComponent implements OnInit, OnDestroy {
     private objetoSessao: IObjetoSessaoModel;
     private objetoErro: ObjetoErro;
     private fazerDownloadImagensBaseSubscription: Subscription;
-    private carregando = false;
+    public carregando = false;
 
 
     constructor(private imagemServico: ImagemService) {

--- a/src/app/paginas/home/home.component.ts
+++ b/src/app/paginas/home/home.component.ts
@@ -21,7 +21,7 @@ export class HomeComponent implements OnInit, OnDestroy {
     public graficoPizza: Chart;
     private objetoErro: ObjetoErro;
     private obterContagemCelulasSubscription: Subscription;
-    private carregando: boolean;
+    public carregando: boolean;
     //#endregion
 
     //#region Construtor

--- a/src/app/paginas/segmentar-imagem/segmentar-imagem.component.ts
+++ b/src/app/paginas/segmentar-imagem/segmentar-imagem.component.ts
@@ -55,8 +55,8 @@ export class SegmentarImagemComponent implements OnInit, OnDestroy {
     private listarSegmentacoesCelulaSubscription: Subscription;
     private listarDescricoesSubscription: Subscription;
     private excluirRegistroDeSegmentacaoSubscription: Subscription;
-    private carregando = false;
-    private rotulo = true;
+    public carregando = false;
+    public rotulo = true;
     //#endregion
 
     //#region Construtores

--- a/src/app/paginas/usuario/usuario.component.ts
+++ b/src/app/paginas/usuario/usuario.component.ts
@@ -14,7 +14,7 @@ export class UsuarioComponent implements OnInit {
 
     @Output() public todosUsuarios: IUsuarioBaseModel[];
     private objetoErro: ObjetoErro;
-    private carregando: boolean;
+    public carregando: boolean;
 
     constructor(private usuarioService: UsuarioService) {
     }


### PR DESCRIPTION
Because

> For a given component all its members (methods, properties) accessed
> by its template must be public in the AOT compilation scenario.
>
> Source: https://stackoverflow.com/a/43177386/1802726

Close https://github.com/CRICDatabase/searchable-image-database-angular/issues/35