### PR TITLE
Fix CRIC_EMAIL loading issue

### DIFF
--- a/src/app/components/footer/footer.component.html
+++ b/src/app/components/footer/footer.component.html
@@ -42,7 +42,7 @@
                     </a>
                 </p>
                 <p> <a class="nav-link-footer"
-                            [href]="linkContactUs"> Contact us </a> </p>
+                            href="mailto:{{contact_us_email}}"> Contact us </a> </p>
             </div>
 
         </div>

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -10,13 +10,13 @@ import { environment } from "src/environments/environment";
 })
 export class FooterComponent implements OnInit {
 
-    public linkContactUs: string;
+    public contact_us_email: string;
     public linkUFOP: string;
     public linkUFC: string;
     public linkUC_BERKELEY: string;
 
     constructor() {
-        this.linkContactUs = `mailto:${environment.email_address}`;
+        this.contact_us_email = environment.email_address;
         this.linkUFOP = LinksExternos.UFOP;
         this.linkUFC = LinksExternos.UFC;
         this.linkUC_BERKELEY = LinksExternos.UC_BERKELEY;


### PR DESCRIPTION
JavaScript's Template literals is lazy
and will only be evaluated during Angular's Template resolution
so `mailto:${environment.email_address}` will search for
a property environment that does NOT exists.